### PR TITLE
:whale: move minfi install to end of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -254,7 +254,14 @@ RUN R -e 'BiocManager::install(c( \
   "uwot", \
   "VennDiagram", \
   "viridis", \
-  "vroom" \
+  "vroom", \
+  "minfi", \
+  "IlluminaHumanMethylation27kmanifest", \
+  "IlluminaHumanMethylation450kmanifest", \
+  "IlluminaHumanMethylationEPICmanifest", \
+  "IlluminaHumanMethylation27kanno.ilmn12.hg19", \
+  "IlluminaHumanMethylation450kanno.ilmn12.hg19", \
+  "IlluminaHumanMethylationEPICanno.ilm10b4.hg19" \
   ))'
 
 
@@ -336,7 +343,7 @@ RUN sudo wget -qO /usr/local/bin/dasel "https://github.com/TomWright/dasel/relea
     sudo chmod a+x /usr/local/bin/dasel
 
 # Needed for minfi
-RUN ${R_HOME}/site-library/littler/examples/installBioc.r minfi IlluminaHumanMethylation27kmanifest IlluminaHumanMethylation450kmanifest IlluminaHumanMethylationEPICmanifest IlluminaHumanMethylation27kanno.ilmn12.hg19 IlluminaHumanMethylation450kanno.ilmn12.hg19 IlluminaHumanMethylationEPICanno.ilm10b4.hg19
+RUN ${R_HOME}/site-library/littler/examples/installBioc.r
 
 # Reset the frontend variable for interactive
 ENV DEBIAN_FRONTEND=

--- a/Dockerfile
+++ b/Dockerfile
@@ -170,9 +170,6 @@ RUN wget http://genometools.org/pub/genometools-1.6.2.tar.gz  && \
     make prefix=/usr/local cairo=no install && \
     cd .. && rm -rf genometools-1.6.2
 
-# Needed for minfi
-RUN ${R_HOME}/site-library/littler/examples/installBioc.r minfi IlluminaHumanMethylation27kmanifest IlluminaHumanMethylation450kmanifest IlluminaHumanMethylationEPICmanifest IlluminaHumanMethylation27kanno.ilmn12.hg19 IlluminaHumanMethylation450kanno.ilmn12.hg19 IlluminaHumanMethylationEPICanno.ilm10b4.hg19
-
 #### R packages
 ###############
 
@@ -337,6 +334,9 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 # Install Desal latest release (v2.1.1)- converter for JSON, TOML, YAML, XML and CSV data formats
 RUN sudo wget -qO /usr/local/bin/dasel "https://github.com/TomWright/dasel/releases/download/v2.1.1/dasel_linux_amd64" && \
     sudo chmod a+x /usr/local/bin/dasel
+
+# Needed for minfi
+RUN ${R_HOME}/site-library/littler/examples/installBioc.r minfi IlluminaHumanMethylation27kmanifest IlluminaHumanMethylation450kmanifest IlluminaHumanMethylationEPICmanifest IlluminaHumanMethylation27kanno.ilmn12.hg19 IlluminaHumanMethylation450kanno.ilmn12.hg19 IlluminaHumanMethylationEPICanno.ilm10b4.hg19
 
 # Reset the frontend variable for interactive
 ENV DEBIAN_FRONTEND=


### PR DESCRIPTION
Move step that installs minfi and other libraries needed for methylation to the end of the Dockerfile. For some reason, having that step near the middle of the Dockerfile doesn't install the libraries.