### PR TITLE
Feature/as/methylation manifest compare

### DIFF
--- a/analyses/methylation-preprocessing/scripts/00-unzip-and-sort.R
+++ b/analyses/methylation-preprocessing/scripts/00-unzip-and-sort.R
@@ -11,6 +11,7 @@
 # 04/03/2025
 
 suppressPackageStartupMessages(library(optparse))
+suppressPackageStartupMessages(library(tidyverse))
 suppressPackageStartupMessages(library(R.utils))
 suppressPackageStartupMessages(library(illuminaio))
 suppressPackageStartupMessages(library(BiocParallel))
@@ -91,14 +92,17 @@ idat_files <- list.files(
     recursive = TRUE
 )
 
-# compare idat_files to man_df$file_name
-not_in_folder <- setdiff(basename(idat_files), basename(man_df$file_name))
-not_in_manifest <- setdiff(basename(man_df$file_name), basename(idat_files))
+dir.create("output_dir")
 
-writeLines(not_in_manifest, file.path("output_dir", "additional_files.txt"))
+# compare idat_files to man_df$file_name
+not_in_manifest <- setdiff(basename(idat_files), basename(man_df$file_name))
+not_in_folder <- setdiff(basename(man_df$file_name), basename(idat_files))
+
+writeLines(not_in_manifest, file.path("additional_files.txt"))
 
 if (length(not_in_folder) > 0) {
-    stop(paste("Error: Can't find the following files in base_dir:",not_in_folder, sep = "\n"))
+    message("Error: Can't find the following files in base_dir:")
+    stop(paste(not_in_folder, sep = "\n"))
 }
 
 message("Unzipping IDAT files")
@@ -128,8 +132,6 @@ all_n_probes <- vapply(all_quants, nrow, integer(1L))
 array_types <- cbind(do.call(rbind, lapply(all_n_probes, .guessArrayTypes)),
     size = all_n_probes
 )
-
-dir.create("output_dir")
 
 unique_array_types <- unique(array_types[, "array"])
 for (array_type in unique_array_types) {

--- a/analyses/methylation-preprocessing/scripts/00-unzip-and-sort.R
+++ b/analyses/methylation-preprocessing/scripts/00-unzip-and-sort.R
@@ -60,17 +60,27 @@ suppressWarnings(
 }
 
 # set up optparse options
-option_list <- list(make_option(
-    opt_str = "--base_dir",
-    type = "character", default = NULL,
-    help = "The absolute path of the base directory containing sample array IDAT files.",
-    metavar = "character"
-))
-
+option_list <- list(
+    make_option(
+        opt_str = "--base_dir",
+        type = "character", default = NULL,
+        help = "The absolute path of the base directory containing sample array IDAT files.",
+        metavar = "character"
+    ),
+    make_option(
+        opt_str = "--manifest_file", type = "character",
+        help = "Input manifest file with 'file_name' and
+              'Bioassay_ID' columns"
+    )
+)
 
 # parse parameter options
 opt <- parse_args(OptionParser(option_list = option_list))
 base_dir <- opt$base_dir
+
+man_df <- read_tsv(file = opt$manifest_file) %>%
+    select(file_name, Bioassay_ID) %>%
+    unique()
 
 message("Finding IDAT files in ", base_dir)
 
@@ -81,6 +91,15 @@ idat_files <- list.files(
     recursive = TRUE
 )
 
+# compare idat_files to man_df$file_name
+not_in_folder <- setdiff(basename(idat_files), basename(man_df$file_name))
+not_in_manifest <- setdiff(basename(man_df$file_name), basename(idat_files))
+
+writeLines(not_in_manifest, file.path("output_dir", "additional_files.txt"))
+
+if (length(not_in_folder) > 0) {
+    stop(paste("Error: Can't find the following files in base_dir:",not_in_folder, sep = "\n"))
+}
 
 message("Unzipping IDAT files")
 

--- a/analyses/methylation-preprocessing/tools/unzip_and_sort_files.cwl
+++ b/analyses/methylation-preprocessing/tools/unzip_and_sort_files.cwl
@@ -27,6 +27,7 @@ arguments:
     1>&2
 inputs:
   input_idats_dir: { type: Directory, loadListing: shallow_listing, inputBinding: { prefix: "--base_dir", position: 1 }, doc: "Directory containing the IDATs to process." }
+  manifest_file: {type: File, inputBinding: { prefix: "--manifest_file", position: 1 }, doc: "Manifest file containing 'file_name' and 'Bioassay_ID' columns"}
   ram: { type: 'int?', default: 32, doc: "GB of RAM to allocate to the task." }
   cores: { type: 'int?', default: 16, doc: "Minimum reserved number of CPU cores for the task." }
 outputs:
@@ -34,3 +35,7 @@ outputs:
     type: 'Directory[]'
     outputBinding:
       glob: 'output_dir/*'
+  additional_files:
+    type: 'File'
+    outputBinding:
+      glob: 'output_dir/additional_files.txt'

--- a/analyses/methylation-preprocessing/tools/unzip_and_sort_files.cwl
+++ b/analyses/methylation-preprocessing/tools/unzip_and_sort_files.cwl
@@ -38,4 +38,4 @@ outputs:
   additional_files:
     type: 'File'
     outputBinding:
-      glob: 'output_dir/additional_files.txt'
+      glob: 'additional_files.txt'

--- a/analyses/methylation-preprocessing/workflow/methylation-preprocessing.cwl
+++ b/analyses/methylation-preprocessing/workflow/methylation-preprocessing.cwl
@@ -33,6 +33,7 @@ inputs:
   cores: { type: 'int?', default: 16, doc: "Minimum reserved number of CPU cores for the task." }
 
 outputs:
+  additional_files: {type: 'File', outputSource: unzip_and_sort_files/additional_files}
   beta_values: {type: 'File[]', outputSource: preprocess_illumina_arrays/beta_values }
   m_values_unmasked: {type: 'File[]', outputSource: preprocess_illumina_arrays/m_values_unmasked }
   m_values_masked: {type: 'File[]', outputSource: preprocess_illumina_arrays/m_values_masked }
@@ -45,7 +46,8 @@ steps:
       input_idats_dir: input_idats_dir
       ram: ram
       cores: cores
-    out: [array_dirs]
+      manifest_file: manifest_file
+    out: [array_dirs, additional_files]
   
   preprocess_illumina_arrays:
     run: ../tools/preprocess_illumina_arrays.cwl


### PR DESCRIPTION
This PR updates the methylation preprocessing workfow and ensures that only samples in the manifest are used for analysis. If a sample is in the manifest but not the input folder, the workflow will fail. If samples are in the input folder but not the manifest, they are reported in a new output file.

Example runs:
- run with files in the manifest not the folder: https://cavatica.sbgenomics.com/u/sicklera/methylation-dev/tasks/4ed56fca-ee2e-47c6-92df-c6151653749a/
- run with files in the folder not the manifest: https://cavatica.sbgenomics.com/u/sicklera/methylation-dev/tasks/775963a7-bde8-4646-9940-fa78fabd21a7/


Closes: https://github.com/rokitalab/OpenPedCan-Project-CNH/issues/80