### PR TITLE
remove files not in manifest from analysis

### DIFF
--- a/analyses/methylation-preprocessing/scripts/00-unzip-and-sort.R
+++ b/analyses/methylation-preprocessing/scripts/00-unzip-and-sort.R
@@ -106,6 +106,9 @@ if (length(not_in_folder) > 0) {
     stop()
 }
 
+# remove idats that aren't in manifest
+idat_files <- idat_files[!basename(idat_files) %in% not_in_manifest]
+
 message("Unzipping IDAT files")
 
 BPREDO <- list()


### PR DESCRIPTION
This PR removes idat files that aren't in the input manifest from analysis.

Closes: #86 