### PR TITLE
update github actions to use latest commit hashes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build Only
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2 #v6.0.2
 
       - name: Free disk space (pre-build)
         run: |
@@ -28,11 +28,11 @@ jobs:
           echo "Disk usage after cleanup:" && df -h
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd #v4.0.0
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf #v6.0.0
         with:
           images: pgc-images.sbgenomics.com/rokita-lab/openpedcanverse
           tags: |
@@ -42,14 +42,14 @@ jobs:
             type=raw,value=analysisjob,enable={{is_default_branch}}
 
       - name: Login to CAVATICA Docker registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
         with:
           registry: pgc-images.sbgenomics.com
           username: ${{ secrets.CAVATICA_USERNAME }}
           password: ${{ secrets.CAVATICA_TOKEN }}
 
       - name: Build
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f #v7.1.0
         with:
           context: .
           push: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build Only
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Free disk space (pre-build)
         run: |
@@ -28,11 +28,11 @@ jobs:
           echo "Disk usage after cleanup:" && df -h
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
         with:
           images: pgc-images.sbgenomics.com/rokita-lab/openpedcanverse
           tags: |
@@ -42,14 +42,14 @@ jobs:
             type=raw,value=analysisjob,enable={{is_default_branch}}
 
       - name: Login to CAVATICA Docker registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: pgc-images.sbgenomics.com
           username: ${{ secrets.CAVATICA_USERNAME }}
           password: ${{ secrets.CAVATICA_TOKEN }}
 
       - name: Build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: .
           push: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build Only
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Free disk space (pre-build)
         run: |

--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build and Publish Image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Free disk space (pre-build)
         run: |

--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build and Publish Image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Free disk space (pre-build)
         run: |
@@ -32,11 +32,11 @@ jobs:
         run: echo "EST_DATE=$(TZ=America/New_York date +%Y-%m-%d)" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Docker meta (openpedcanverse)
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
         with:
           images: pgc-images.sbgenomics.com/rokita-lab/openpedcanverse
           tags: |
@@ -46,14 +46,14 @@ jobs:
             type=raw,value=est-${{ env.EST_DATE }}
 
       - name: Login to Cavatica Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: pgc-images.sbgenomics.com
           username: ${{ secrets.CAVATICA_USERNAME }}
           password: ${{ secrets.CAVATICA_TOKEN }}
 
       - name: Build and push openpedcanverse
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build and Publish Image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2 #v6.0.2
 
       - name: Free disk space (pre-build)
         run: |
@@ -32,11 +32,11 @@ jobs:
         run: echo "EST_DATE=$(TZ=America/New_York date +%Y-%m-%d)" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd #v4.0.0
 
       - name: Docker meta (openpedcanverse)
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf #v6.0.0
         with:
           images: pgc-images.sbgenomics.com/rokita-lab/openpedcanverse
           tags: |
@@ -46,14 +46,14 @@ jobs:
             type=raw,value=est-${{ env.EST_DATE }}
 
       - name: Login to Cavatica Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
         with:
           registry: pgc-images.sbgenomics.com
           username: ${{ secrets.CAVATICA_USERNAME }}
           password: ${{ secrets.CAVATICA_TOKEN }}
 
       - name: Build and push openpedcanverse
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f #v7.1.0
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/count-git-contributions.yml
+++ b/.github/workflows/count-git-contributions.yml
@@ -19,7 +19,7 @@ jobs:
     # We want to count the contributions to the dev branch
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2 #v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           ref: "dev"
           fetch-depth: 0

--- a/.github/workflows/count-git-contributions.yml
+++ b/.github/workflows/count-git-contributions.yml
@@ -81,7 +81,7 @@ jobs:
     # We want to add the updated metadata to the manuscript repo
     steps:
       - name: Checkout manuscript repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2 #v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           repository: rokitalab/OpenPedCan-manuscript
       

--- a/.github/workflows/count-git-contributions.yml
+++ b/.github/workflows/count-git-contributions.yml
@@ -19,7 +19,7 @@ jobs:
     # We want to count the contributions to the dev branch
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2 #v6.0.2
         with:
           ref: "dev"
           fetch-depth: 0
@@ -41,21 +41,21 @@ jobs:
 
       # Upload the manuscript YAML as an artifact
       - name: Upload metadata YAML artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
           name: manuscript_metadata
           path: analyses/count-contributions/results/metadata.yaml
 
       # Upload the author information as an artifact
       - name: Upload author information TSV artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
           name: author_information
           path: analyses/count-contributions/author_information.tsv
 
       # Create a pull request with the updated results
       - name: Create PR with updated contribution module
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 #v8.1.1
         with:
           token: ${{ secrets.GH_TOKEN }}
           commit-message: Rerun count-contributions analysis module
@@ -81,7 +81,7 @@ jobs:
     # We want to add the updated metadata to the manuscript repo
     steps:
       - name: Checkout manuscript repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2 #v6.0.2
         with:
           repository: rokitalab/OpenPedCan-manuscript
       
@@ -101,14 +101,14 @@ jobs:
           rm content/metadata.yaml
 
       - name: Download the metadata artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
         with:
           name: manuscript_metadata
           path: content
 
 
       - name: Download the author information artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
         with:
           name: author_information
           path: submission_info
@@ -116,7 +116,7 @@ jobs:
 
       # Create a pull request with the updated results
       - name: Create PR with updated manuscript metadata YAML
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 #v8.1.1
         with:
           token: ${{ secrets.GH_TOKEN }}
           commit-message: Update manuscript metadata

--- a/.github/workflows/count-git-contributions.yml
+++ b/.github/workflows/count-git-contributions.yml
@@ -19,7 +19,7 @@ jobs:
     # We want to count the contributions to the dev branch
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: "dev"
           fetch-depth: 0
@@ -41,21 +41,21 @@ jobs:
 
       # Upload the manuscript YAML as an artifact
       - name: Upload metadata YAML artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: manuscript_metadata
           path: analyses/count-contributions/results/metadata.yaml
 
       # Upload the author information as an artifact
       - name: Upload author information TSV artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: author_information
           path: analyses/count-contributions/author_information.tsv
 
       # Create a pull request with the updated results
       - name: Create PR with updated contribution module
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           token: ${{ secrets.GH_TOKEN }}
           commit-message: Rerun count-contributions analysis module
@@ -81,7 +81,7 @@ jobs:
     # We want to add the updated metadata to the manuscript repo
     steps:
       - name: Checkout manuscript repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: rokitalab/OpenPedCan-manuscript
       
@@ -101,14 +101,14 @@ jobs:
           rm content/metadata.yaml
 
       - name: Download the metadata artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: manuscript_metadata
           path: content
 
 
       - name: Download the author information artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: author_information
           path: submission_info
@@ -116,7 +116,7 @@ jobs:
 
       # Create a pull request with the updated results
       - name: Create PR with updated manuscript metadata YAML
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           token: ${{ secrets.GH_TOKEN }}
           commit-message: Update manuscript metadata

--- a/.github/workflows/run_analysis.yml
+++ b/.github/workflows/run_analysis.yml
@@ -8,7 +8,7 @@ jobs:
     name: Run Analysis - Consensus CN Manta
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2 #v6.0.2
       - name: free disk space
         run: |
           echo "Disk usage before cleanup:" && df -h
@@ -42,7 +42,7 @@ jobs:
     needs: consensus_cn_manta
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2 #v6.0.2
       - name: free disk space
         run: |
           echo "Disk usage before cleanup:" && df -h
@@ -199,7 +199,7 @@ jobs:
           #  entrypoint: rnaseq-batch-correct/run_ruvseq.sh
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2 #v6.0.2
       - name: free disk space
         run: |
           echo "Disk usage before cleanup:" && df -h

--- a/.github/workflows/run_analysis.yml
+++ b/.github/workflows/run_analysis.yml
@@ -8,7 +8,7 @@ jobs:
     name: Run Analysis - Consensus CN Manta
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: free disk space
         run: |
           echo "Disk usage before cleanup:" && df -h

--- a/.github/workflows/run_analysis.yml
+++ b/.github/workflows/run_analysis.yml
@@ -199,7 +199,7 @@ jobs:
           #  entrypoint: rnaseq-batch-correct/run_ruvseq.sh
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: free disk space
         run: |
           echo "Disk usage before cleanup:" && df -h

--- a/.github/workflows/run_analysis.yml
+++ b/.github/workflows/run_analysis.yml
@@ -42,7 +42,7 @@ jobs:
     needs: consensus_cn_manta
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2 #v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: free disk space
         run: |
           echo "Disk usage before cleanup:" && df -h

--- a/.github/workflows/run_analysis.yml
+++ b/.github/workflows/run_analysis.yml
@@ -8,7 +8,7 @@ jobs:
     name: Run Analysis - Consensus CN Manta
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: free disk space
         run: |
           echo "Disk usage before cleanup:" && df -h
@@ -42,7 +42,7 @@ jobs:
     needs: consensus_cn_manta
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: free disk space
         run: |
           echo "Disk usage before cleanup:" && df -h
@@ -199,7 +199,7 @@ jobs:
           #  entrypoint: rnaseq-batch-correct/run_ruvseq.sh
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: free disk space
         run: |
           echo "Disk usage before cleanup:" && df -h


### PR DESCRIPTION
This PR updates all of the githb actions (other than add issue) to use the commit hash of their respective latest release.