### PR TITLE
 liftover and combine seg files for gistic

### DIFF
--- a/analyses/methylation-preprocessing/run-preprocess-illumina-arrays.sh
+++ b/analyses/methylation-preprocessing/run-preprocess-illumina-arrays.sh
@@ -72,3 +72,10 @@ run_cnv () {
 run_cnv "sorted_idats_output_dir/IlluminaHumanMethylationEPICv2" "EPICv2" "EPICv2" 
 run_cnv "sorted_idats_output_dir/IlluminaHumanMethylationEPIC"   "EPICv1" "EPIC"
 run_cnv "sorted_idats_output_dir/IlluminaHumanMethylation450k"   "450k"   "450"
+
+mkdir -p liftover
+cd liftover
+curl -O http://hgdownload.soe.ucsc.edu/goldenPath/hg19/liftOver/hg19ToHg38.over.chain.gz
+cd ..
+
+Rscript --vanilla scripts/04-liftover.R --seg_dir test-out

--- a/analyses/methylation-preprocessing/scripts/04-liftover.R
+++ b/analyses/methylation-preprocessing/scripts/04-liftover.R
@@ -1,0 +1,103 @@
+library(tidyverse)
+library(rtracklayer)
+library(GenomicRanges)
+
+# set up optparse options
+option_list <- list(
+  make_option(opt_str = "--seg_dir", type = "character", default = NULL,
+              help = "The path where the seg files are located",
+              metavar = "character")
+)
+
+
+# parse parameter options
+opt <- parse_args(OptionParser(option_list = option_list))
+seg_dir <- opt$seg_dir
+
+# Magrittr pipe
+`%>%` <- dplyr::`%>%`
+
+
+# Locate SEG files
+gistic_seg_files <- list.files(seg_dir, pattern = "\\gistic.seg$", full.names = TRUE)
+
+
+#Detect platform from filename
+
+detect_platform <- function(f) {
+  f <- basename(f)
+  if (grepl("EPICv2", f, ignore.case = TRUE)) return("EPICv2")
+  if (grepl("EPIC-", f, ignore.case = TRUE)) return("EPIC")
+  if (grepl("450", f, ignore.case = TRUE)) return("450k")
+  return("unknown")
+}
+
+seg_df_list <- lapply(gistic_seg_files, function(f) {
+  df <- read_tsv(f, show_col_types = FALSE)
+  df$platform <- detect_platform(f)
+  df$source_file <- basename(f)
+  df
+})
+
+all_segs <- bind_rows(seg_df_list)
+
+# -----------------------------
+# 3. Split by platform
+# -----------------------------
+seg_epicv2 <- all_segs %>% filter(platform == "EPICv2")
+seg_legacy <- all_segs %>% filter(platform %in% c("450k", "EPIC"))
+
+
+# Liftover (hg19 to hg38)
+
+
+# Load chain file
+chain <- import.chain("liftover/hg19ToHg38.over.chain")
+lift_seg <- function(df, chain) {
+  gr <- GRanges(
+    seqnames = paste0("chr", df$Chromosome),
+    ranges = IRanges(start = df$Start_Position, end = df$End_Position)
+  )
+  
+  lifted <- liftOver(gr, chain)
+  
+  # Keep only segments that map uniquely to ONE region
+  keep <- lengths(lifted) == 1
+  
+  gr_lifted <- unlist(lifted[keep])
+  df <- df[keep, ]
+  
+  # Replace coordinates
+  df$Chromosome <- as.character(seqnames(gr_lifted))
+  df$Chromosome <- gsub("^chr", "", df$Chromosome)
+  df$Start_Position <- start(gr_lifted)
+  df$End_Position <- end(gr_lifted)
+  
+  df
+}
+
+
+if (nrow(seg_legacy) > 0) {
+  seg_legacy_hg38 <- lift_seg(seg_legacy, chain)
+} else {
+  seg_legacy_hg38 <- NULL
+}
+
+
+# Combine all segments (hg38)
+
+seg_epicv2 <- seg_epicv2 %>%
+  mutate(Chromosome = as.character(Chromosome))
+
+seg_legacy_hg38 <- seg_legacy_hg38 %>%
+  mutate(Chromosome = as.character(Chromosome))
+combined_seg <- bind_rows(
+  seg_epicv2,     # already hg38
+  seg_legacy_hg38 # lifted
+)
+
+combined_seg <- combined_seg %>%
+  dplyr::select(-platform, -source_file)
+
+#Write output
+write_tsv(combined_seg, file = file.path(seg_dir, "combined_hg38.gistic.seg"))


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What scientific question is your analysis addressing?

- EPICv2 is on hg38, EPICv1 and 450k are hg19. This script performs liftover on the gistic files from v1 and 450k, then combines with v2 to make one segfile. 
- I have considered a lot of different ways of doing this, including intersecting probes before conumee, or combining the results after gistic. 
- intersecting before conumee does not work because conumee does not like working with v2 and v1 together, and will only use hg19 for EPICv1 and 450k probes. 
- combining after can be problematic because gistic did not work well with the 450k results on their own as there were so few samples.  


#### What was your approach?



#### What GitHub issue does your pull request address?



### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.

#### Which areas should receive a particularly close look?



#### Is there anything that you want to discuss further?



#### Is the analysis in a mature enough form that the resulting figure(s) and/or table(s) are ready for review?



### Results

#### What types of results are included (e.g., table, figure)?



#### What is your summary of the results?



#### Reproducibility Checklist

<!-- Check all those that apply or remove this section if it is not applicable.-->

- [ ] The dependencies required to run the code in this pull request have been added to the project Dockerfile.
- [ ] This analysis has been added to continuous integration.

#### Documentation Checklist

<!-- Please review https://github.com/AlexsLemonade/OpenPBTA-analysis#documenting-your-analysis -->

- [ ] This analysis module has a `README` and it is up to date.
- [ ] This analysis is recorded in the table in `analyses/README.md` and the entry is up to date.
- [ ] The analytical code is documented and contains comments.

<!-- IF YOUR PULL REQUEST IS A DATA RELEASE, PLEASE REMOVE THE [HTML COMMENT TAG](https://html.com/tags/comment-tag/) FROM THE SECTION BELOW AND COMPLETE THE CHECKLIST-->

<!-- 
### Data Release Checklist
- [ ] Is the table in doc/data-file-descriptions.md up to date?
- [ ] Is doc/data-format.md up to date?
- [ ] Is doc/release-notes.md up to date?
- [ ] Is download-data.sh up to date?
- [ ] Was download-data.sh tested and did it complete without error?
-->
